### PR TITLE
Fix dark mode UI contrast and mobile select layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-icons": "^5.5.0"
       },
       "devDependencies": {
+        "@types/node": "^25.6.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -25,6 +26,8 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "playwright": "^1.59.1",
+        "tsx": "^4.21.0",
         "typescript": "^5.2.2",
         "vite": "^5.2.0"
       }
@@ -59,6 +62,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -388,6 +392,7 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.4.tgz",
       "integrity": "sha512-oa07UG7Lic5hHSQtGRiMEnYjuhIa8lszyuVhZjZqR2Ap3VMF688y1MVPJ1pK+8OwY5uhXBgVd5c0+rI8aBZlwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@chakra-ui/utils": "2.2.5",
         "csstype": "^3.1.2"
@@ -492,6 +497,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -535,6 +541,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -869,6 +876,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -886,6 +910,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -901,6 +942,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1638,6 +1696,17 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -1657,6 +1726,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1712,6 +1782,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1920,6 +1991,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2087,6 +2159,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2373,6 +2446,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2713,6 +2787,7 @@
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
       "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "motion-dom": "^11.18.1",
         "motion-utils": "^11.18.1",
@@ -2798,6 +2873,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmmirror.com/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -3469,6 +3557,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmmirror.com/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -3555,6 +3690,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3579,6 +3715,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3737,6 +3874,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/reusify": {
@@ -4012,6 +4159,459 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmmirror.com/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4044,6 +4644,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4051,6 +4652,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4142,6 +4750,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "tsx --test src/**/*.test.tsx",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -19,6 +20,7 @@
     "react-icons": "^5.5.0"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -27,6 +29,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "playwright": "^1.59.1",
+    "tsx": "^4.21.0",
     "typescript": "^5.2.2",
     "vite": "^5.2.0"
   }

--- a/src/App.responsive.test.tsx
+++ b/src/App.responsive.test.tsx
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const VITE_BIN = fileURLToPath(
+  new URL("../node_modules/vite/bin/vite.js", import.meta.url)
+);
+
+async function getOpenPort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  server.close();
+  await once(server, "close");
+
+  if (!address || typeof address === "string") {
+    throw new Error("Could not allocate a local test port");
+  }
+
+  return address.port;
+}
+
+async function startVite(port: number) {
+  const appUrl = `http://127.0.0.1:${port}/depth-of-field/`;
+  const server = spawn(
+    process.execPath,
+    [VITE_BIN, "--host", "127.0.0.1", "--port", String(port), "--strictPort"],
+    { stdio: ["ignore", "pipe", "pipe"] }
+  );
+
+  let output = "";
+  server.stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  server.stderr.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(appUrl);
+      if (response.ok) {
+        return { server, appUrl };
+      }
+    } catch {
+      // Keep polling until the dev server accepts connections.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  server.kill();
+  throw new Error(`Vite server did not start:\n${output}`);
+}
+
+test("sensor select has enough visible width on narrow mobile screens", async () => {
+  const port = await getOpenPort();
+  const { server, appUrl } = await startVite(port);
+
+  try {
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+
+    await page.goto(appUrl, { waitUntil: "networkidle" });
+
+    const sensorSelect = page.getByRole("combobox").first();
+    const width = await sensorSelect.evaluate((select) => ({
+      client: select.clientWidth,
+      scroll: select.scrollWidth,
+    }));
+
+    await browser.close();
+
+    assert.ok(
+      width.client >= width.scroll,
+      `expected sensor select visible width ${width.client}px to fit ${width.scroll}px of content`
+    );
+  } finally {
+    server.kill();
+    await once(server, "exit").catch(() => undefined);
+  }
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
 import { TbRuler, TbAperture, TbZoomIn, TbUser } from "react-icons/tb";
 import { FiGithub, FiCamera, FiSun, FiMoon } from "react-icons/fi";
 import { toImperial, toMetric } from "./utils/units";
+import { buildNativeSelectStyles } from "./selectStyles";
 
 import PhotographyGraphic, { SUBJECTS } from "./PhotographyGraphic";
 
@@ -253,6 +254,8 @@ const cropFactor = isCustomSensor
   const borderColor = useColorModeValue("gray.200", "gray.600");
   const mutedText = useColorModeValue("gray.500", "gray.400");
   const topBarBg = useColorModeValue("gray.50", "gray.900");
+  const graphicTextColor = useColorModeValue("#1A202C", "#F7FAFC");
+  const nativeSelectStyles = buildNativeSelectStyles(colorMode);
 
   const labelStyles = {
     mt: "2",
@@ -317,6 +320,7 @@ const cropFactor = isCustomSensor
           aperture={aperture}
           system={system}
           verticalFieldOfView={verticalFieldOfView}
+          textColor={graphicTextColor}
           onChangeDistance={(val) => setDistanceToSubjectInInches(val)}
         />
       </Box>
@@ -581,9 +585,16 @@ const cropFactor = isCustomSensor
       />
     </Flex>
   </Box>
-)}<Flex gap={2}>
-            <Flex gap={2} width="50%">
-              <Flex w="20%" mt={2} justify="flex-end" align="center" gap={1.5}>
+)}<Flex gap={3} direction={{ base: "column", md: "row" }}>
+            <Flex gap={2} width={{ base: "100%", md: "50%" }}>
+              <Flex
+                w={{ base: "72px", md: "20%" }}
+                mt={2}
+                justify="flex-end"
+                align="center"
+                gap={1.5}
+                flexShrink={0}
+              >
                 <Icon as={FiCamera} boxSize={4} color={mutedText} />
                 <Text fontSize="sm" textAlign="right">
                   Sensor
@@ -591,6 +602,14 @@ const cropFactor = isCustomSensor
               </Flex>
               <Box flexGrow={1}>
                 <Select
+                  bg={nativeSelectStyles.bg}
+                  color={nativeSelectStyles.color}
+                  borderColor={nativeSelectStyles.borderColor}
+                  iconColor={nativeSelectStyles.iconColor}
+                  _hover={nativeSelectStyles._hover}
+                  _focus={nativeSelectStyles._focus}
+                  _active={nativeSelectStyles._active}
+                  sx={nativeSelectStyles.sx}
                   value={sensor}
                   placeholder="Sensor"
                   onChange={(evt) => {
@@ -610,8 +629,15 @@ const cropFactor = isCustomSensor
               </Box>
             </Flex>
 
-            <Flex gap={2} width="50%">
-              <Flex w="20%" mt={2} justify="flex-end" align="center" gap={1.5}>
+            <Flex gap={2} width={{ base: "100%", md: "50%" }}>
+              <Flex
+                w={{ base: "72px", md: "20%" }}
+                mt={2}
+                justify="flex-end"
+                align="center"
+                gap={1.5}
+                flexShrink={0}
+              >
                 <Icon as={TbUser} boxSize={4} color={mutedText} />
                 <Text fontSize="sm" textAlign="right">
                   Subject
@@ -619,6 +645,14 @@ const cropFactor = isCustomSensor
               </Flex>
               <Box flexGrow={1}>
                 <Select
+                  bg={nativeSelectStyles.bg}
+                  color={nativeSelectStyles.color}
+                  borderColor={nativeSelectStyles.borderColor}
+                  iconColor={nativeSelectStyles.iconColor}
+                  _hover={nativeSelectStyles._hover}
+                  _focus={nativeSelectStyles._focus}
+                  _active={nativeSelectStyles._active}
+                  sx={nativeSelectStyles.sx}
                   value={subject}
                   placeholder="Subject"
                   onChange={(evt) => {

--- a/src/PhotographyGraphic.test.tsx
+++ b/src/PhotographyGraphic.test.tsx
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import PhotographyGraphic from "./PhotographyGraphic";
+
+test("applies an explicit fill to SVG labels so they stay visible in dark mode", () => {
+  const markup = renderToStaticMarkup(
+    <PhotographyGraphic
+      distanceToSubjectInInches={72}
+      nearFocalPointInInches={60}
+      farFocalPointInInches={90}
+      farDistanceInInches={360}
+      subject="Human"
+      focalLength={50}
+      aperture={1.8}
+      system="Imperial"
+      verticalFieldOfView={27}
+      textColor="#f7fafc"
+    />
+  );
+
+  assert.match(markup, /<text[^>]*fill="#f7fafc"/i);
+});
+
+test("renders vertical distance labels with a dark clipped overlay inside the field-of-view area", () => {
+  const markup = renderToStaticMarkup(
+    <PhotographyGraphic
+      distanceToSubjectInInches={72}
+      nearFocalPointInInches={60}
+      farFocalPointInInches={90}
+      farDistanceInInches={360}
+      subject="Human"
+      focalLength={50}
+      aperture={1.8}
+      system="Imperial"
+      verticalFieldOfView={27}
+      textColor="#f7fafc"
+    />
+  );
+
+  assert.match(markup, /clip-path="url\(#fov\)"/i);
+  assert.match(markup, /<text[^>]*fill="#1a202c"[^>]*rotate\(-90\)/i);
+  assert.match(markup, /<text[^>]*fill="#1a202c"[^>]*rotate\(90\)/i);
+});

--- a/src/PhotographyGraphic.tsx
+++ b/src/PhotographyGraphic.tsx
@@ -41,6 +41,9 @@ const HumanAtDesk = () => (
   />
 );
 
+// SUBJECTS is shared by App and this component; keeping it here avoids moving
+// the large inline SVG paths into a separate module.
+// eslint-disable-next-line react-refresh/only-export-components
 export const SUBJECTS = {
   Human: {
     graphic: Human,
@@ -137,6 +140,7 @@ export default function PhotographyGraphic({
   aperture,
   system,
   verticalFieldOfView,
+  textColor,
   onChangeDistance,
 }: {
   distanceToSubjectInInches: number;
@@ -147,6 +151,7 @@ export default function PhotographyGraphic({
   aperture: number;
   system: string;
   verticalFieldOfView: number;
+  textColor?: string;
   subject: keyof typeof SUBJECTS;
   onChangeDistance?: (distance: number) => void;
 }) {
@@ -177,6 +182,35 @@ export default function PhotographyGraphic({
 
   const SubjectGraphic = SUBJECTS[subject].graphic;
   const height = SUBJECTS[subject].height;
+  const textFill = textColor ?? "currentColor";
+  const clippedTextFill = "#1A202C";
+  const shouldShowVerticalLabels =
+    farFocalPointInInches - nearFocalPointInInches > 18;
+
+  function renderVerticalDistanceLabels(fill: string) {
+    return (
+      <>
+        <text
+          fill={fill}
+          fontSize={3}
+          textAnchor="start"
+          transform={`translate(${nearFocalPointInInches - 0.5} ${
+            height - 1
+          }) rotate(-90)`}
+        >
+          {convertUnits(nearFocalPointInInches, 0)}
+        </text>
+        <text
+          fill={fill}
+          fontSize={3}
+          textAnchor="start"
+          transform={`translate(${farFocalPointInInches + 0.5} 1) rotate(90)`}
+        >
+          {convertUnits(farFocalPointInInches, 0)}
+        </text>
+      </>
+    );
+  }
 
   const viewPath = buildViewPath(
     0,
@@ -194,7 +228,7 @@ export default function PhotographyGraphic({
       onMouseMove={onMouseMove}
       xmlns="http://www.w3.org/2000/svg"
       viewBox={`-43.5 0 ${farDistanceInInches} ${height + 12}`}
-      style={{ width: "100%", height: "auto" }}
+      style={{ width: "100%", height: "auto", color: textColor }}
     >
       <defs>
         <style>
@@ -260,39 +294,29 @@ export default function PhotographyGraphic({
           (farFocalPointInInches - nearFocalPointInInches) / 2
         }
         y={height + 10.7}
+        fill={textFill}
         fontSize={3}
         textAnchor="middle"
       >
         {convertUnits(farFocalPointInInches - nearFocalPointInInches)}
       </text>
 
-      <text x={-1} y={5} fontSize={4} fontWeight="bold" textAnchor="end">
+      <text
+        x={-1}
+        y={5}
+        fill={textFill}
+        fontSize={4}
+        fontWeight="bold"
+        textAnchor="end"
+      >
         {focalLength}mm f/{aperture}
       </text>
 
-      {farFocalPointInInches - nearFocalPointInInches > 18 && (
-        <>
-          <text
-            fontSize={3}
-            textAnchor="start"
-            transform={`translate(${nearFocalPointInInches - 0.5} ${
-              height - 1
-            }) rotate(-90)`}
-          >
-            {convertUnits(nearFocalPointInInches, 0)}
-          </text>
-          <text
-            fontSize={3}
-            textAnchor="start"
-            transform={`translate(${farFocalPointInInches + 0.5} 1) rotate(90)`}
-          >
-            {convertUnits(farFocalPointInInches, 0)}
-          </text>
-        </>
-      )}
+      {shouldShowVerticalLabels && renderVerticalDistanceLabels(textFill)}
       <text
         x={distanceToSubjectInInches}
         y={height + 3.5}
+        fill={textFill}
         fontSize={3}
         textAnchor="middle"
       >
@@ -309,6 +333,11 @@ export default function PhotographyGraphic({
           <SubjectGraphic />
         </g>
       </g>
+      {shouldShowVerticalLabels && (
+        <g clipPath="url(#fov)">
+          {renderVerticalDistanceLabels(clippedTextFill)}
+        </g>
+      )}
 
       <line
         x1={distanceToSubjectInInches}

--- a/src/selectStyles.test.tsx
+++ b/src/selectStyles.test.tsx
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildNativeSelectStyles } from "./selectStyles";
+
+test("dark-mode select styles keep a stable dark background across interaction states", () => {
+  const styles = buildNativeSelectStyles("dark");
+
+  assert.equal(styles.bg, "gray.700");
+  assert.equal(styles._hover.bg, styles.bg);
+  assert.equal(styles._focus.bg, styles.bg);
+  assert.equal(styles._active.bg, styles.bg);
+  assert.equal(styles.sx.colorScheme, "dark");
+  assert.equal(
+    styles.sx["& > option"].background,
+    "var(--chakra-colors-gray-700)"
+  );
+});

--- a/src/selectStyles.ts
+++ b/src/selectStyles.ts
@@ -1,0 +1,86 @@
+export type NativeSelectStyles = {
+  bg: string;
+  color: string;
+  borderColor: string;
+  iconColor: string;
+  _hover: {
+    bg: string;
+    borderColor: string;
+  };
+  _focus: {
+    bg: string;
+    borderColor: string;
+    boxShadow: string;
+  };
+  _active: {
+    bg: string;
+    borderColor: string;
+  };
+  sx: {
+    colorScheme: "light" | "dark";
+    "& > option": {
+      background: string;
+      color: string;
+    };
+  };
+};
+
+export function buildNativeSelectStyles(
+  colorMode: "light" | "dark"
+): NativeSelectStyles {
+  if (colorMode === "dark") {
+    return {
+      bg: "gray.700",
+      color: "whiteAlpha.900",
+      borderColor: "whiteAlpha.300",
+      iconColor: "whiteAlpha.700",
+      _hover: {
+        bg: "gray.700",
+        borderColor: "whiteAlpha.400",
+      },
+      _focus: {
+        bg: "gray.700",
+        borderColor: "blue.300",
+        boxShadow: "0 0 0 1px var(--chakra-colors-blue-300)",
+      },
+      _active: {
+        bg: "gray.700",
+        borderColor: "blue.300",
+      },
+      sx: {
+        colorScheme: "dark",
+        "& > option": {
+          background: "var(--chakra-colors-gray-700)",
+          color: "var(--chakra-colors-whiteAlpha-900)",
+        },
+      },
+    };
+  }
+
+  return {
+    bg: "white",
+    color: "gray.800",
+    borderColor: "gray.200",
+    iconColor: "gray.500",
+    _hover: {
+      bg: "white",
+      borderColor: "gray.300",
+    },
+    _focus: {
+      bg: "white",
+      borderColor: "blue.500",
+      boxShadow: "0 0 0 1px var(--chakra-colors-blue-500)",
+    },
+    _active: {
+      bg: "white",
+      borderColor: "blue.500",
+    },
+    sx: {
+      colorScheme: "light",
+      "& > option": {
+        background: "var(--chakra-colors-white)",
+        color: "var(--chakra-colors-gray-800)",
+      },
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "types": ["node"],
     "jsx": "react-jsx",
 
     /* Linting */


### PR DESCRIPTION
## Summary
This PR fixes a couple of dark mode and small-screen UI issues in the depth-of-field simulator.

- Adds theme-aware styling for native sensor/subject selects so they keep readable text, borders, icons, and option backgrounds in dark mode.
- Passes an explicit text color into the SVG photography graphic so labels stay visible when the app switches themes.
- Renders clipped dark overlay labels inside the field-of-view area so vertical distance labels remain readable over the light FOV shape.
- Stacks the sensor and subject select controls on narrow screens to avoid truncating longer sensor names like `35mm (full frame)`.
- Adds regression coverage for select styling, SVG label color, clipped label rendering, and mobile select width.

## Test Plan
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
